### PR TITLE
Add encryption support and service worker

### DIFF
--- a/cryptoHelper.js
+++ b/cryptoHelper.js
@@ -1,0 +1,61 @@
+const CryptoHelper = (() => {
+  const passphrase = 'cubekill-secret';
+  const salt = new TextEncoder().encode('cubekill-salt');
+  let keyPromise = null;
+
+  async function getKey() {
+    if (keyPromise) return keyPromise;
+    const enc = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw', enc.encode(passphrase), { name: 'PBKDF2' }, false, ['deriveKey']
+    );
+    keyPromise = crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+    return keyPromise;
+  }
+
+  function bufToBase64(buf) {
+    let binary = '';
+    const bytes = new Uint8Array(buf);
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+
+  function base64ToBuf(str) {
+    const binary = atob(str);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  return {
+    async encrypt(obj) {
+      const key = await getKey();
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const encoded = new TextEncoder().encode(JSON.stringify(obj));
+      const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+      const combined = new Uint8Array(iv.byteLength + ciphertext.byteLength);
+      combined.set(iv, 0);
+      combined.set(new Uint8Array(ciphertext), iv.byteLength);
+      return bufToBase64(combined);
+    },
+    async decrypt(str) {
+      const data = base64ToBuf(str);
+      const key = await getKey();
+      const iv = data.slice(0, 12);
+      const ciphertext = data.slice(12);
+      const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: new Uint8Array(iv) }, key, new Uint8Array(ciphertext));
+      return JSON.parse(new TextDecoder().decode(plaintext));
+    }
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -1,18 +1,16 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
-
 <head>
-
-
+  <meta charset="utf-8">
   <title>Cube Hell</title>
   <link rel="manifest" href="MyPWA.json">
+  <link rel="stylesheet" type="text/css" href="style.css">
   <script>
-
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
         navigator.serviceWorker.register('/service-worker.js')
-          .then(registration => {
-            console.log('Service worker registered successfully:', registration);
+          .then(reg => {
+            console.log('Service worker registered successfully:', reg);
           })
           .catch(error => {
             console.log('Service worker registration failed:', error);
@@ -20,49 +18,18 @@
       });
     }
   </script>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   <script src="ajax/libs/p5.js/1.4.1/p5.js"></script>
-  <script><script src="libraries/p5.dom.min.js"></script>
-
+  <script src="libraries/p5.dom.min.js"></script>
   <script src="libraries/p5.touchgui.js"></script>
   <script src="libraries/p5livemedia.js"></script>
   <script src="libraries/p5play.js"></script>
   <script src="libraries/planck.min.js"></script>
   <script src="libraries/simplepeer.min.js"></script>
   <script src="libraries/socket.io.js"></script>
-
+  <script src="cryptoHelper.js"></script>
   <script src="sketch.js"></script>
-
-
-  <link rel="stylesheet" type="text/css" href="style.css">
-  <meta charset="utf-8">
-
-
-
-
-
-</script></head>
-
+</head>
 <body>
-  <main>
-
-  </main>
-
-
+  <main></main>
 </body>
-
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,26 @@
+const CACHE_NAME = 'cubekill-cache-v1';
+const FILES_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/sketch.js',
+  '/cryptoHelper.js',
+  '/ajax/libs/p5.js/1.4.1/p5.js',
+  '/libraries/p5.dom.min.js',
+  '/libraries/p5.touchgui.js',
+  '/libraries/p5livemedia.js',
+  '/libraries/p5play.js',
+  '/libraries/planck.min.js',
+  '/libraries/simplepeer.min.js',
+  '/libraries/socket.io.js'
+];
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE))
+  );
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/sketch.js
+++ b/sketch.js
@@ -898,7 +898,7 @@ function draw() {
       //lifeBullet: newbulletLife,
     };
 
-    p5lm.send(JSON.stringify(dataToSend));
+    CryptoHelper.encrypt(dataToSend).then(enc => p5lm.send(enc));
     //-----------------------------------------
     //recived
   }
@@ -1222,7 +1222,7 @@ function draw() {
     //lifeBullet: newbulletLife,
   };
 
-  p5le.send(JSON.stringify(dataToSend1));
+  CryptoHelper.encrypt(dataToSend1).then(enc => p5le.send(enc));
 }
 
 
@@ -1264,7 +1264,7 @@ function resetLoby(winner) {
   };
 
   print(datatosend3);
-  p5ls.send(JSON.stringify(datatosend3));
+  CryptoHelper.encrypt(datatosend3).then(enc => p5ls.send(enc));
 
 
 
@@ -1315,20 +1315,16 @@ function gotScore(data, id) {
   //reset and state who won
 }
 
-function gotData1(data, id) {
-  let d = JSON.parse(data);
+async function gotData1(data, id) {
+  const d = await CryptoHelper.decrypt(data);
   bufferplayer = d.player;
   bulletXoff = d.bulletsX;
   bulletYoff = d.bulletsy;
   lifeoff = d.lifebullet;
 }
 
-function gotData(data, id) {
-  //print(id + ":" + data);
-
-  data = data;
-  // If it is JSON, parse it
-  let d = JSON.parse(data);
+async function gotData(data, id) {
+  const d = await CryptoHelper.decrypt(data);
   bulletX = d.bulletsX;
   bulletY = d.bulletsy;
   life = d.lifebullet;
@@ -1361,7 +1357,7 @@ Array.prototype.removeAllCurrent = function() {
       this.splice(i, 1);
     }
   }
-  this.lenght = 0;
+  this.length = 0;
 };
 
 


### PR DESCRIPTION
## Summary
- fix markup in `index.html` and include new scripts
- add service worker for caching
- introduce `cryptoHelper.js` with AES-GCM helpers
- encrypt and decrypt network data in `sketch.js`
- fix `removeAllCurrent` bug

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840e98361288333b227de629d71423f